### PR TITLE
map colums from imported file to cohortdata columns

### DIFF
--- a/R/mod_ImportCohortsFromFile.R
+++ b/R/mod_ImportCohortsFromFile.R
@@ -27,7 +27,11 @@ mod_importCohortsFromFile_server <- function(id, r_connectionHandlers, r_workben
     #
     r <- shiny::reactiveValues(
       uploadedFile = NULL,
-      cohortDataUploaded = NULL
+      cohortDataUploaded = NULL,
+      cohortData = NULL,
+      original_colnames = NULL,
+      assigned_colnames = NULL,
+      columnNamesOK = FALSE
     )
 
     r_toAdd <- shiny::reactiveValues(
@@ -57,6 +61,90 @@ mod_importCohortsFromFile_server <- function(id, r_connectionHandlers, r_workben
     })
 
     #
+    # keep the current selection in a reactive
+    #
+    observe({
+      # shiny::req(input$cohort_name)
+      shiny::req(input$person_source_value)
+      shiny::req(input$cohort_start_date)
+      shiny::req(input$cohort_end_date)
+
+      r$assigned_colnames <- c(input$cohort_name, input$person_source_value, input$cohort_start_date, input$cohort_end_date)
+    })
+
+    #
+    # check the current assignment, revisit if needed
+    #
+    observeEvent(input$ok, {
+      removeModal()
+      # error checking before removing
+      if(is.null(r$assigned_colnames)){
+        showModal(assignmentDialog(failed = TRUE, "All columns must be assigned!"))
+        return()
+      }
+      if(length(unique(r$assigned_colnames)) != 4){
+        showModal(assignmentDialog(failed = TRUE, "Column assignments must be unique!"))
+        return()
+      }
+      r$columnNamesOK <- TRUE
+    })
+
+    #
+    # helper function for the assignment dialog
+    #
+    assignmentDialog <- function(failed = FALSE, message = ""){
+      modalDialog(
+        title = "Assign column names",
+        fluidRow(column(8, div(style = "margin-left:20px;",
+                                shinyWidgets::pickerInput(
+                                  inputId = ns("cohort_name"),
+                                  label = "Column for cohort name",
+                                  choices = r$original_colnames,
+                                  selected = isolate(input$cohort_name),
+                                  inline = FALSE,
+                                  width = 'auto'
+                                )))
+        ),
+        fluidRow(column(8, div(style = "margin-left:20px;",
+                                shinyWidgets::pickerInput(
+                                  inputId = ns("person_source_value"),
+                                  label = "Column for person identifier",
+                                  choices = r$original_colnames,
+                                  selected = ifelse("finngenid" %in% r$original_colnames, "finngenid", ""),
+                                  inline = FALSE,
+                                  width = 'auto'
+                                )))
+        ),
+        fluidRow(column(8, div(style = "margin-left:20px;",
+                                shinyWidgets::pickerInput(
+                                  inputId = ns("cohort_start_date"),
+                                  label = "Column for cohort start date",
+                                  choices = r$original_colnames,
+                                  selected = isolate(input$cohort_start_date),
+                                  inline = FALSE,
+                                  width = 'auto'
+                                )))
+        ),
+        fluidRow(column(8, div(style = "margin-left:20px;",
+                                shinyWidgets::pickerInput(
+                                  inputId = ns("cohort_end_date"),
+                                  label = "Column for cohort end date",
+                                  choices = r$original_colnames,
+                                  selected = isolate(input$cohort_end_date),
+                                  inline = FALSE,
+                                  width = 'auto'
+                                )))
+        ),
+        footer = tagList(
+          modalButton("Cancel"),
+          actionButton(ns("ok"), "OK")
+        ),
+        if (failed)
+          div(tags$b(message, style = "color: red;")),
+      )
+    }
+
+    #
     # updates r$cohortDefinitionSetImported with uploaded file, or with error
     #
     shiny::observe({
@@ -67,37 +155,67 @@ mod_importCohortsFromFile_server <- function(id, r_connectionHandlers, r_workben
 
       # passing error to shiny::validate
       if(ext != "tsv" & ext != "csv"){
-        r$cohortDefinitionSetImported <- "ERROR READING FILE:\nI need to know if the file is in .tsv or .csv format, please set the extension acordingly"
+        r$cohortDefinitionSetImported <- "ERROR READING FILE:\nI need to know if the file is in .tsv or .csv format, please set the extension accordingly"
         return()
       }
 
       if(ext == "tsv"){ cohortData <- HadesExtras::readCohortData(r$uploadedFile$datapath, delim = "\t") }
       if(ext == "csv"){ cohortData <- HadesExtras::readCohortData(r$uploadedFile$datapath, delim = ",") }
 
+      # we expect lowercase names
+      colnames(cohortData) <- stringr::str_to_lower(colnames(cohortData))
+
+      r$original_colnames <- c("", colnames(cohortData))
+      r$cohortDataUploaded   <- cohortData
+
+      if(length(colnames(cohortData)) < 4){
+        showModal(assignmentDialog(failed = TRUE, "There must be at least 4 columns!"))
+      } else if(!all(c("cohort_name", "person_source_value", "cohort_start_date", "cohort_end_date") %in% colnames(cohortData))){
+        showModal(assignmentDialog())
+      } else {
+        r$columnNamesOK <- TRUE
+      }
+    })
+
+    #
+    # rename the columns
+    #
+    shiny::observe({
+      shiny::req(r$columnNamesOK)
+      shiny::req(r$cohortDataUploaded)
+
+      if(is.null(r$assigned_colnames)){
+        cohortData <- r$cohortDataUploaded
+      } else {
+        required_colnames <- c("cohort_name", "person_source_value", "cohort_start_date", "cohort_end_date")
+        cohortData <- r$cohortDataUploaded |> dplyr::rename_with(~ required_colnames, all_of(r$assigned_colnames))
+      }
+
+      r$columnNamesOK <- FALSE
+      r$assigned_colnames <- NULL
 
       isCohortData <- HadesExtras::checkCohortData(cohortData)
 
       # passing error to shiny::validate
       if(is.character(isCohortData)){
-        r$cohortDataUploaded <- paste(c("ERROR READING COHORTDATA FILE:", isCohortData), sep = "\n")
+        r$cohortData <- paste(c("ERROR READING COHORTDATA FILE:", isCohortData), sep = "\n")
       }else{
-        r$cohortDataUploaded <- cohortData
+        r$cohortData <- cohortData
       }
-
     })
 
     #
     # updates output$cohorts_reactable with r$cohortDefinitionSetImported
     #
     output$cohorts_reactable <- reactable::renderReactable({
-      shiny::req(r$cohortDataUploaded)
+      shiny::req(r$cohortData)
       shiny::req(input$selectDatabases_pickerInput)
 
       shiny::validate(
-        shiny::need(!is.character(r$cohortDataUploaded), r$cohortDataUploaded)
+        shiny::need(!is.character(r$cohortData), r$cohortData)
       )
 
-      .reactatable_cohortData(r$cohortDataUploaded)
+      .reactatable_cohortData(r$cohortData)
 
     })
 
@@ -113,16 +231,16 @@ mod_importCohortsFromFile_server <- function(id, r_connectionHandlers, r_workben
 
     shiny::observeEvent(input$import_actionButton, {
       shiny::req(r_selectedIndex())
-      shiny::req(r$cohortDataUploaded)
+      shiny::req(r$cohortData)
       shiny::req(input$selectDatabases_pickerInput)
 
-      selectedCohortNames <- r$cohortDataUploaded |>
+      selectedCohortNames <- r$cohortData |>
         dplyr::distinct(cohort_name) |>
         dplyr::arrange(cohort_name) |>
         dplyr::slice(r_selectedIndex()) |>
         dplyr::pull(cohort_name)
 
-      selectedCohortData <- r$cohortDataUploaded |>
+      selectedCohortData <- r$cohortData |>
         dplyr::filter(cohort_name %in% selectedCohortNames)
 
 
@@ -154,11 +272,14 @@ mod_importCohortsFromFile_server <- function(id, r_connectionHandlers, r_workben
       shinyjs::reset("uploadedFile")
       r$uploadedFile <- NULL
       r$cohortDataUploaded <- NULL
+      r$cohortData <- NULL
       r_toAdd$cohortDefinitionSet <- NULL
       reactable::updateReactable("cohorts_reactable", selected = NA, session = session )
     })
 
   })
+
+
 }
 
 
@@ -194,7 +315,6 @@ mod_importCohortsFromFile_server <- function(id, r_connectionHandlers, r_workben
   return(table)
 
 }
-
 
 
 

--- a/R/mod_ImportCohortsFromFile.R
+++ b/R/mod_ImportCohortsFromFile.R
@@ -166,6 +166,7 @@ mod_importCohortsFromFile_server <- function(id, r_connectionHandlers, r_workben
       colnames(cohortData) <- stringr::str_to_lower(colnames(cohortData))
 
       r$original_colnames <- c("", colnames(cohortData))
+      r$assigned_colnames <- c(isolate(input$cohort_name), isolate(input$person_source_value), isolate(input$cohort_start_date), isolate(input$cohort_end_date))
       r$cohortDataUploaded   <- cohortData
 
       if(length(colnames(cohortData)) < 4){
@@ -173,6 +174,7 @@ mod_importCohortsFromFile_server <- function(id, r_connectionHandlers, r_workben
       } else if(!all(c("cohort_name", "person_source_value", "cohort_start_date", "cohort_end_date") %in% colnames(cohortData))){
         showModal(assignmentDialog())
       } else {
+        r$assigned_colnames <- NULL
         r$columnNamesOK <- TRUE
       }
     })

--- a/renv.lock
+++ b/renv.lock
@@ -2031,7 +2031,12 @@
     "renv": {
       "Package": "renv",
       "Version": "1.0.3",
-      "Source": "Repository"
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "utils"
+      ],
+      "Hash": "41b847654f567341725473431dd0d5ab"
     },
     "rlang": {
       "Package": "rlang",

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.3.0",
+    "Version": "4.3.1",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -761,10 +761,10 @@
     },
     "commonmark": {
       "Package": "commonmark",
-      "Version": "1.9.0",
+      "Version": "1.9.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "d691c61bff84bd63c383874d2d0c3307"
+      "Hash": "5d8225445acb167abf7797de48b2ee3c"
     },
     "cowplot": {
       "Package": "cowplot",
@@ -2111,10 +2111,10 @@
     },
     "rstudioapi": {
       "Package": "rstudioapi",
-      "Version": "0.14",
+      "Version": "0.15.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "690bd2acc42a9166ce34845884459320"
+      "Hash": "5564500e25cffad9e22244ced1379887"
     },
     "rversions": {
       "Package": "rversions",


### PR DESCRIPTION
Implements the following changes:

- if the imported cohort is not in the 'cohortdata' format a dialog opens giving a chance to assign the columns
- the time window slider does not return overlapping windows anymore
