### PR TITLE
77 import from atlaslibrary slow copy if it has been ran as to ran in atlas

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,9 +44,10 @@ Remotes:
     OHDSI/CohortGenerator,
     OHDSI/ResultModelManager,
     OHDSI/Eunomia,
+    OHDSI/OhdsiShinyModules,
     javier-gracia-tabuenca-tuni/CohortDiagnostics@fix-error-with-no-conceptset-cohorts,
-    FINNGEN/HadesExtras,
-    FINNGEN/FinnGenUtilsR@23-move-to-this-package-the-code-to-run-gwas
+    FINNGEN/HadesExtras@experimental-ak,
+    FINNGEN/FinnGenUtilsR
 Suggests: 
     gert,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Remotes:
     OHDSI/Eunomia,
     OHDSI/OhdsiShinyModules,
     javier-gracia-tabuenca-tuni/CohortDiagnostics@fix-error-with-no-conceptset-cohorts,
-    FINNGEN/HadesExtras@experimental-ak,
+    FINNGEN/HadesExtras,
     FINNGEN/FinnGenUtilsR
 Suggests: 
     gert,

--- a/R/app_Run.R
+++ b/R/app_Run.R
@@ -18,7 +18,6 @@ run_app <- function(pathToCohortOperationsConfigYalm, pathToDatabasesConfigYalm,
   databasesConfig <- yaml::read_yaml(pathToDatabasesConfigYalm)
   checkmate::assertList(databasesConfig, names = "named")
 
-
   # set shiny to accept large files
   options(shiny.maxRequestSize = 1000000000)
 

--- a/R/mod_ExportCohorts.R
+++ b/R/mod_ExportCohorts.R
@@ -155,7 +155,6 @@ mod_exportsCohorts_server <- function(id, r_connectionHandlers, r_workbench) {
 
     shiny::observe({
       shiny::req(r$writeErrorMessage)
-      browser()
       if (r$writeErrorMessage == ""){
         shinyWidgets::show_alert(
           title = "Download completed successfully",

--- a/R/mod_FormTimeWindows.R
+++ b/R/mod_FormTimeWindows.R
@@ -154,7 +154,7 @@ mod_formTimeWindows_server <- function(id, session) {
       shinyjs::toggle(id = "slider_help")
     })
 
-    output$the_window_output <- renderText({
+    output$the_window_output <- shiny::renderText({
       req(input$the_slider)
       breaks <- as.vector(input$the_slider)
       if(input$zero_window && !0 %in% breaks) breaks <- c(0, breaks)

--- a/R/mod_ImportCohortsFromAtlas.R
+++ b/R/mod_ImportCohortsFromAtlas.R
@@ -222,7 +222,7 @@ mod_importCohortsFromAtlas_server <- function(id, r_connectionHandlers, r_workbe
         ParallelLogger::logInfo("[Import from Atlas-", filterCohortsRegex,"] Importing cohorts (create new): ",
                                 cohortDefinitionSetCreate$cohortName,
                                 " with ids: ", cohortDefinitionSetCreate$cohortId,
-                                " to database", input$selectDatabases_pickerInput) # currently selected picker
+                                " to database ", input$selectDatabases_pickerInput) # currently selected picker
 
       }
 
@@ -291,8 +291,6 @@ mod_importCohortsFromAtlas_server <- function(id, r_connectionHandlers, r_workbe
       cohortDefinitions <- dplyr::bind_rows(
         cohortDefinitionSetCopyExisting, cohortDefinitionSetCreate
       )
-
-      browser()
 
       # add list
       r_toAdd$cohortDefinitionSet <- NULL # cohortDefinitions

--- a/R/mod_ImportCohortsFromAtlas.R
+++ b/R/mod_ImportCohortsFromAtlas.R
@@ -89,7 +89,6 @@ mod_importCohortsFromAtlas_server <- function(id, r_connectionHandlers, r_workbe
         id = reactable::colDef(name = "Cohort ID", show = (filterCohortsRegex == '*') ),
         name = reactable::colDef(name = "Cohort Name"),
         description = reactable::colDef(name = "Description")
-
       )
 
       atlasCohortsTable |>
@@ -125,7 +124,7 @@ mod_importCohortsFromAtlas_server <- function(id, r_connectionHandlers, r_workbe
       sourcesAtlas <- as.data.frame(ROhdsiWebApi::getCdmSources(baseUrl = webApiUrl))
       rownames(sourcesAtlas) <- sourcesAtlas$sourceKey
 
-      # cdm schemas
+      # cdm schemas - selects value for the currently selected picker - loads all cohorts from a single OMOP
       cohortTableHandler <- r_connectionHandlers$databasesHandlers[[input$selectDatabases_pickerInput]]$cohortTableHandle
       cdmDatabaseSchema  <- cohortTableHandler$cdmDatabaseSchema
       vocabularyDatabaseSchema  <-  cohortTableHandler$vocabularyDatabaseSchema
@@ -187,6 +186,8 @@ mod_importCohortsFromAtlas_server <- function(id, r_connectionHandlers, r_workbe
         cohortInfo$cdmSourcesMapped <- unname(sapply(cohortInfo$cdmDatabaseSchema, function(k) length(grep(k, cdmDatabaseSchema))) > 0)
         cohortInfo <- cohortInfo[which(cohortInfo$cdmSourcesMapped), ]
 
+
+
         if (nrow(cohortInfo) >= 1){
 
           # take the latest generation information
@@ -221,7 +222,7 @@ mod_importCohortsFromAtlas_server <- function(id, r_connectionHandlers, r_workbe
         ParallelLogger::logInfo("[Import from Atlas-", filterCohortsRegex,"] Importing cohorts (create new): ",
                                 cohortDefinitionSetCreate$cohortName,
                                 " with ids: ", cohortDefinitionSetCreate$cohortId,
-                                " to database", input$selectDatabases_pickerInput)
+                                " to database", input$selectDatabases_pickerInput) # currently selected picker
 
       }
 
@@ -291,8 +292,10 @@ mod_importCohortsFromAtlas_server <- function(id, r_connectionHandlers, r_workbe
         cohortDefinitionSetCopyExisting, cohortDefinitionSetCreate
       )
 
+      browser()
+
       # add list
-      r_toAdd$cohortDefinitionSet <- cohortDefinitions
+      r_toAdd$cohortDefinitionSet <- NULL # cohortDefinitions
       remove_sweetAlert_spinner()
 
     })
@@ -332,10 +335,10 @@ mod_importCohortsFromAtlas_server <- function(id, r_connectionHandlers, r_workbe
   }
 
   totbytes <- sum(as.numeric(estimations))
-  cost <- totbytes * 1e-12 * 6.25
 
-  ParallelLogger::logInfo("[Import from Atlas] Importing existing cohorts cost estimation: ",
-                          (cost),"$ (", totbytes * 1e-9, "GB of data)")
+  ParallelLogger::logInfo("[Import from Atlas] Importing existing
+                          cohorts billing estimation: ",
+                          totbytes * 1e-9, "GB")
 
 }
 

--- a/R/mod_ImportCohortsFromAtlas.R
+++ b/R/mod_ImportCohortsFromAtlas.R
@@ -275,7 +275,7 @@ mod_importCohortsFromAtlas_server <- function(id, r_connectionHandlers, r_workbe
                                 filterCohortsRegex,"] Importing cohorts (copy existing): ",
                                 paste0(cohortDefinitionSetCopyExisting$cohortName, collapse = ", "),
                                 " with ids: ", paste0(cohortDefinitionSetCopyExisting$cohortId, collapse = ", "),
-                                " to database", input$selectDatabases_pickerInput)
+                                " to database ", input$selectDatabases_pickerInput)
 
         tryCatch({
           .estimate_costs(cohortDefinitionSetCopyExisting$sql, cdmSchemaProjectId)
@@ -293,7 +293,7 @@ mod_importCohortsFromAtlas_server <- function(id, r_connectionHandlers, r_workbe
       )
 
       # add list
-      r_toAdd$cohortDefinitionSet <- NULL # cohortDefinitions
+      r_toAdd$cohortDefinitionSet <- cohortDefinitions
       remove_sweetAlert_spinner()
 
     })

--- a/R/mod_ImportCohortsFromAtlas.R
+++ b/R/mod_ImportCohortsFromAtlas.R
@@ -220,8 +220,8 @@ mod_importCohortsFromAtlas_server <- function(id, r_connectionHandlers, r_workbe
         cohortDefinitionSetCreate$cohortGenerated <- FALSE
 
         ParallelLogger::logInfo("[Import from Atlas-", filterCohortsRegex,"] Importing cohorts (create new): ",
-                                cohortDefinitionSetCreate$cohortName,
-                                " with ids: ", cohortDefinitionSetCreate$cohortId,
+                                paste0(cohortDefinitionSetCreate$cohortName, collapse = ", "),
+                                " with ids: ", paste0(cohortDefinitionSetCreate$cohortId, collapse = ", "),
                                 " to database ", input$selectDatabases_pickerInput) # currently selected picker
 
       }
@@ -273,8 +273,8 @@ mod_importCohortsFromAtlas_server <- function(id, r_connectionHandlers, r_workbe
 
         ParallelLogger::logInfo("[Import from Atlas-",
                                 filterCohortsRegex,"] Importing cohorts (copy existing): ",
-                                cohortDefinitionSetCopyExisting$cohortName,
-                                " with ids: ", cohortDefinitionSetCopyExisting$cohortId,
+                                paste0(cohortDefinitionSetCopyExisting$cohortName, collapse = ", "),
+                                " with ids: ", paste0(cohortDefinitionSetCopyExisting$cohortId, collapse = ", "),
                                 " to database", input$selectDatabases_pickerInput)
 
         tryCatch({
@@ -332,11 +332,10 @@ mod_importCohortsFromAtlas_server <- function(id, r_connectionHandlers, r_workbe
     estimations <- c(estimations, e)
   }
 
-  totbytes <- sum(as.numeric(estimations))
+  totbytes <- round(sum(as.numeric(estimations)))
 
-  ParallelLogger::logInfo("[Import from Atlas] Importing existing
-                          cohorts billing estimation: ",
-                          totbytes * 1e-9, "GB")
+  ParallelLogger::logInfo("[Import from Atlas] Importing existing cohorts billing estimation: ",
+                          totbytes * 1e-9," GB (", totbytes, "b)")
 
 }
 

--- a/R/mod_ImportCohortsFromCohortTable.R
+++ b/R/mod_ImportCohortsFromCohortTable.R
@@ -104,12 +104,12 @@ mod_importCohortsFromCohortsTable_server <- function(id, r_connectionHandlers, r
 
     })
     # reactive function to get selected values
-    r_selectedIndex <- reactive(reactable::getReactableState("cohorts_reactable", "selected", session))
+    r_selectedIndex <- shiny::reactive(reactable::getReactableState("cohorts_reactable", "selected", session))
 
     #
     # button import selected: checks selected cohorts
     #
-    observe({
+    shiny::observe({
       shinyjs::toggleState("import_actionButton", condition = !is.null(r_selectedIndex()) )
     })
 

--- a/R/mod_ImportCohortsFromFile.R
+++ b/R/mod_ImportCohortsFromFile.R
@@ -171,7 +171,7 @@ mod_importCohortsFromFile_server <- function(id, r_connectionHandlers, r_workben
     #
     # check the current assignment, revisit if needed
     #
-    observeEvent(input$ok, {
+    shiny::observeEvent(input$ok, {
       removeModal()
 
       cohort_name <- isolate(input$cohort_name)

--- a/renv.lock
+++ b/renv.lock
@@ -57,13 +57,13 @@
       "Package": "CohortDiagnostics",
       "Version": "3.2.5",
       "Source": "GitHub",
+      "Remotes": "ohdsi/Eunomia, ohdsi/FeatureExtraction, ohdsi/ResultModelManager, ohdsi/ROhdsiWebApi, ohdsi/CirceR, ohdsi/CohortGenerator, ohdsi/OhdsiShinyModules",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteUsername": "javier-gracia-tabuenca-tuni",
       "RemoteRepo": "CohortDiagnostics",
+      "RemoteUsername": "javier-gracia-tabuenca-tuni",
       "RemoteRef": "fix-error-with-no-conceptset-cohorts",
       "RemoteSha": "46d72aaf678307b7d3200e19aea5aa193e730697",
-      "Remotes": "ohdsi/Eunomia, ohdsi/FeatureExtraction, ohdsi/ResultModelManager, ohdsi/ROhdsiWebApi, ohdsi/CirceR, ohdsi/CohortGenerator, ohdsi/OhdsiShinyModules",
       "Requirements": [
         "Andromeda",
         "CohortGenerator",
@@ -89,21 +89,22 @@
     },
     "CohortGenerator": {
       "Package": "CohortGenerator",
-      "Version": "0.9.0",
+      "Version": "0.10.0",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "OHDSI",
       "RemoteRepo": "CohortGenerator",
       "RemoteRef": "main",
-      "RemoteSha": "e3efad630b8b2c0376431a88fde89e6c4bbac38c",
-      "Remotes": "ohdsi/CirceR, ohdsi/Eunomia, ohdsi/ROhdsiWebApi",
+      "RemoteSha": "dc3bde3172f5d823dc1c27d709da4cdfcfb0ea3b",
+      "Remotes": "ohdsi/ResultModelManager, ohdsi/ROhdsiWebApi,",
       "Requirements": [
         "DatabaseConnector",
         "ParallelLogger",
         "R",
         "R6",
         "RJSONIO",
+        "ResultModelManager",
         "SqlRender",
         "bit64",
         "checkmate",
@@ -111,11 +112,13 @@
         "dplyr",
         "jsonlite",
         "lubridate",
+        "methods",
         "readr",
         "rlang",
-        "stringi"
+        "stringi",
+        "tibble"
       ],
-      "Hash": "a441009fb11cba8bf31e1ccf17fed82a"
+      "Hash": "8ced746e41ef35e0d089432af95b0025"
     },
     "CommonDataModel": {
       "Package": "CommonDataModel",
@@ -212,14 +215,14 @@
     },
     "FeatureExtraction": {
       "Package": "FeatureExtraction",
-      "Version": "3.5.2",
+      "Version": "3.6.0",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "OHDSI",
       "RemoteRepo": "FeatureExtraction",
       "RemoteRef": "main",
-      "RemoteSha": "f4536fb75e5c32399c91270f6b6e35c8e95fdf1e",
+      "RemoteSha": "a0bbc9bf86f21afd764563033316ed86de8f1186",
       "Requirements": [
         "Andromeda",
         "DBI",
@@ -238,7 +241,7 @@
         "readr",
         "rlang"
       ],
-      "Hash": "e686d93264359802fdccd41989c51386"
+      "Hash": "8d8c00cfb0eae562e9bb94c780c91e29"
     },
     "FinnGenUtilsR": {
       "Package": "FinnGenUtilsR",
@@ -249,7 +252,7 @@
       "RemoteUsername": "FINNGEN",
       "RemoteRepo": "FinnGenUtilsR",
       "RemoteRef": "master",
-      "RemoteSha": "fb9249481721cd5fe784ee3cc3688a024b0eba5f",
+      "RemoteSha": "8a12d2de62ec716eafbb65e8309bd9857c498c0a",
       "Requirements": [
         "DBI",
         "DatabaseConnector",
@@ -268,7 +271,7 @@
         "tibble",
         "yaml"
       ],
-      "Hash": "efeacd73c701756d9deb85899f4e3ce5"
+      "Hash": "f4f20632790518607f530e21b18babcd"
     },
     "HadesExtras": {
       "Package": "HadesExtras",
@@ -278,8 +281,8 @@
       "RemoteHost": "api.github.com",
       "RemoteUsername": "FINNGEN",
       "RemoteRepo": "HadesExtras",
-      "RemoteRef": "master",
-      "RemoteSha": "3daa8c316c259a7501b713ac67d9e32ae43ca11f",
+      "RemoteRef": "experimental-ak",
+      "RemoteSha": "97063596295e454b7178c3fe2dc7375e2b1557bd",
       "Remotes": "OHDSI/DatabaseConnector, OHDSI/FeatureExtraction, OHDSI/CohortGenerator, OHDSI/ResultModelManager, OHDSI/Eunomia, javier-gracia-tabuenca-tuni/CohortDiagnostics@fix-error-with-no-conceptset-cohorts",
       "Requirements": [
         "CohortDiagnostics",
@@ -313,7 +316,7 @@
         "tippy",
         "validate"
       ],
-      "Hash": "1120355800854d18baeaaf821652f372"
+      "Hash": "b5054977ea515189672576a4fb074888"
     },
     "MASS": {
       "Package": "MASS",
@@ -349,15 +352,15 @@
     },
     "OhdsiShinyModules": {
       "Package": "OhdsiShinyModules",
-      "Version": "2.1.4",
+      "Version": "2.1.5",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteUsername": "ohdsi",
+      "RemoteUsername": "OHDSI",
       "RemoteRepo": "OhdsiShinyModules",
       "RemoteRef": "main",
-      "RemoteSha": "42f5bb42c731fd9ff1a9c96bb68b624fd357ba78",
-      "Remotes": "ohdsi/CirceR, ohdsi/ResultModelManager",
+      "RemoteSha": "815d0c8b44c96e359a6183a2f9bf94211c2166f8",
+      "Remotes": "ohdsi/ResultModelManager",
       "Requirements": [
         "CirceR",
         "DT",
@@ -394,7 +397,7 @@
         "tidyselect",
         "tippy"
       ],
-      "Hash": "0d9716d5aa6050be213d2b1ab13fb2d7"
+      "Hash": "986af58d6e26135b29dc74e4bffdccaf"
     },
     "ParallelLogger": {
       "Package": "ParallelLogger",
@@ -502,14 +505,14 @@
     },
     "ResultModelManager": {
       "Package": "ResultModelManager",
-      "Version": "0.5.8",
+      "Version": "0.5.9",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "OHDSI",
       "RemoteRepo": "ResultModelManager",
       "RemoteRef": "main",
-      "RemoteSha": "ad706b4396d8285a8930c9b99ec09e927e403b00",
+      "RemoteSha": "d939010caf5fdc4e898c6e6d1c68d39dc86dc77f",
       "Requirements": [
         "DBI",
         "DatabaseConnector",
@@ -525,13 +528,14 @@
         "pool",
         "readr",
         "rlang",
+        "withr",
         "zip"
       ],
-      "Hash": "f664eac6620a8d5a9a3365b4aed4caf4"
+      "Hash": "c61b8bc75b92103f1248e7e1a2f04f3b"
     },
     "SqlRender": {
       "Package": "SqlRender",
-      "Version": "1.17.0",
+      "Version": "1.18.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -539,7 +543,7 @@
         "rJava",
         "rlang"
       ],
-      "Hash": "513c5e6da774c913430561a3912c5354"
+      "Hash": "e1762de0f08b14658d74989c10e2f265"
     },
     "anytime": {
       "Package": "anytime",
@@ -755,14 +759,14 @@
     },
     "cachem": {
       "Package": "cachem",
-      "Version": "1.0.8",
+      "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "fastmap",
         "rlang"
       ],
-      "Hash": "c35768291560ce302c0a6589f92e837d"
+      "Hash": "cd9a672193789068eb5a2aad65a0dedf"
     },
     "callr": {
       "Package": "callr",
@@ -779,7 +783,7 @@
     },
     "checkmate": {
       "Package": "checkmate",
-      "Version": "2.3.1",
+      "Version": "2.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -787,7 +791,7 @@
         "backports",
         "utils"
       ],
-      "Hash": "c01cab1cb0f9125211a6fc99d540e315"
+      "Hash": "0e14e01ce07e7c88fd25de6d4260d26b"
     },
     "cli": {
       "Package": "cli",
@@ -830,7 +834,7 @@
       "Package": "codetools",
       "Version": "0.2-19",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R"
       ],
@@ -1131,10 +1135,10 @@
     },
     "fastmap": {
       "Package": "fastmap",
-      "Version": "1.1.1",
+      "Version": "1.2.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "f7736a18de97dea803bde0a2daaafb27"
+      "Hash": "aa5e1cd11c2d15497494c5292d7ffcc8"
     },
     "filelock": {
       "Package": "filelock",
@@ -1187,7 +1191,7 @@
     },
     "future": {
       "Package": "future",
-      "Version": "1.33.2",
+      "Version": "1.34.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1198,7 +1202,7 @@
         "parallelly",
         "utils"
       ],
-      "Hash": "fd7b1d69d16d0d114e4fa82db68f184c"
+      "Hash": "475771e3edb711591476be387c9a8c2e"
     },
     "gargle": {
       "Package": "gargle",
@@ -1235,7 +1239,7 @@
     },
     "gert": {
       "Package": "gert",
-      "Version": "2.0.1",
+      "Version": "2.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1246,7 +1250,7 @@
         "sys",
         "zip"
       ],
-      "Hash": "f70d3fe2d9e7654213a946963d1591eb"
+      "Hash": "bdc909d9f16e2478d615b0e6a7330435"
     },
     "ggplot2": {
       "Package": "ggplot2",
@@ -1537,7 +1541,7 @@
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.47",
+      "Version": "1.48",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1549,7 +1553,7 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "7c99b2d55584b982717fcc0950378612"
+      "Hash": "acf380f300c721da9fde7df115a5f86f"
     },
     "labeling": {
       "Package": "labeling",
@@ -1761,7 +1765,7 @@
     },
     "parallelly": {
       "Package": "parallelly",
-      "Version": "1.37.1",
+      "Version": "1.38.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1769,7 +1773,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "5410df8d22bd36e616f2a2343dbb328c"
+      "Hash": "6e8b139c1904f5e9e14c69db64453bbe"
     },
     "pillar": {
       "Package": "pillar",
@@ -2154,13 +2158,13 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.0.3",
+      "Version": "1.0.7",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "41b847654f567341725473431dd0d5ab"
+      "Hash": "397b7b2a265bc5a7a06852524dabae20"
     },
     "rlang": {
       "Package": "rlang",
@@ -2198,7 +2202,7 @@
     },
     "roxygen2": {
       "Package": "roxygen2",
-      "Version": "7.3.1",
+      "Version": "7.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2220,7 +2224,7 @@
         "withr",
         "xml2"
       ],
-      "Hash": "c25fe7b2d8cba73d1b63c947bf7afdb9"
+      "Hash": "6ee25f9054a70f44d615300ed531ba8d"
     },
     "rprojroot": {
       "Package": "rprojroot",
@@ -2311,7 +2315,7 @@
     },
     "shiny": {
       "Package": "shiny",
-      "Version": "1.8.1.1",
+      "Version": "1.9.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2340,7 +2344,7 @@
         "withr",
         "xtable"
       ],
-      "Hash": "54b26646816af9960a4c64d8ceec75d6"
+      "Hash": "6a293995a66e12c48d13aa1f957d09c7"
     },
     "shinyFeedback": {
       "Package": "shinyFeedback",
@@ -2913,10 +2917,10 @@
     },
     "yaml": {
       "Package": "yaml",
-      "Version": "2.3.8",
+      "Version": "2.3.10",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "29240487a071f535f5e5d5a323b7afbd"
+      "Hash": "51dab85c6c98e50a18d7551e9d49f76c"
     },
     "zip": {
       "Package": "zip",

--- a/renv.lock
+++ b/renv.lock
@@ -193,6 +193,16 @@
       ],
       "Hash": "8d66bf120b0c2ffc0d8ed1809a37ea2d"
     },
+    "Deriv": {
+      "Package": "Deriv",
+      "Version": "4.1.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "methods"
+      ],
+      "Hash": "bc727aba82bcda74db0bbe188ec6757c"
+    },
     "Eunomia": {
       "Package": "Eunomia",
       "Version": "2.0.0",
@@ -281,8 +291,8 @@
       "RemoteHost": "api.github.com",
       "RemoteUsername": "FINNGEN",
       "RemoteRepo": "HadesExtras",
-      "RemoteRef": "experimental-ak",
-      "RemoteSha": "aa9100b5f328e6ecc519823fd948f60c5e0639a7",
+      "RemoteRef": "master",
+      "RemoteSha": "2580bc0f3dcef07ebcb9f315eeb462a4e2d1ca23",
       "Remotes": "OHDSI/DatabaseConnector, OHDSI/FeatureExtraction, OHDSI/CohortGenerator, OHDSI/ResultModelManager, OHDSI/Eunomia, javier-gracia-tabuenca-tuni/CohortDiagnostics@fix-error-with-no-conceptset-cohorts",
       "Requirements": [
         "CohortDiagnostics",
@@ -316,7 +326,7 @@
         "tippy",
         "validate"
       ],
-      "Hash": "c654bddf2e28817c7c6371dfe491ec51"
+      "Hash": "09bdbc827917f97ed95913b1406ac4e5"
     },
     "MASS": {
       "Package": "MASS",
@@ -350,17 +360,30 @@
       ],
       "Hash": "1a00d4828f33a9d690806e98bd17150c"
     },
+    "MatrixModels": {
+      "Package": "MatrixModels",
+      "Version": "0.5-3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Matrix",
+        "R",
+        "methods",
+        "stats"
+      ],
+      "Hash": "0776bf7526869e0286b0463cb72fb211"
+    },
     "OhdsiShinyModules": {
       "Package": "OhdsiShinyModules",
-      "Version": "2.1.5",
+      "Version": "3.0.0",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "OHDSI",
       "RemoteRepo": "OhdsiShinyModules",
       "RemoteRef": "main",
-      "RemoteSha": "815d0c8b44c96e359a6183a2f9bf94211c2166f8",
-      "Remotes": "ohdsi/ResultModelManager",
+      "RemoteSha": "5a7b6789582e9959f1105676f31ab37f877f76d7",
+      "Remotes": "ohdsi/ReportGenerator, ohdsi/ResultModelManager",
       "Requirements": [
         "CirceR",
         "DT",
@@ -369,6 +392,7 @@
         "R",
         "RColorBrewer",
         "RJSONIO",
+        "ReportGenerator",
         "SqlRender",
         "checkmate",
         "cowplot",
@@ -379,6 +403,7 @@
         "lubridate",
         "markdown",
         "methods",
+        "openxlsx",
         "plotly",
         "purrr",
         "reactable",
@@ -390,6 +415,7 @@
         "shinyWidgets",
         "shinycssloaders",
         "shinydashboard",
+        "shinyglide",
         "stringi",
         "stringr",
         "tibble",
@@ -397,11 +423,11 @@
         "tidyselect",
         "tippy"
       ],
-      "Hash": "986af58d6e26135b29dc74e4bffdccaf"
+      "Hash": "39e1025119c175a7d87b5c7e922c286c"
     },
     "ParallelLogger": {
       "Package": "ParallelLogger",
-      "Version": "3.3.0",
+      "Version": "3.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -412,7 +438,7 @@
         "utils",
         "xml2"
       ],
-      "Hash": "fd636fc067099b75b8ad17e9104b10f3"
+      "Hash": "062731c28e80ccf47134ed5e8efbd019"
     },
     "R6": {
       "Package": "R6",
@@ -503,16 +529,55 @@
       ],
       "Hash": "5ea2700d21e038ace58269ecdbeb9ec0"
     },
+    "RcppEigen": {
+      "Package": "RcppEigen",
+      "Version": "0.3.4.0.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "stats",
+        "utils"
+      ],
+      "Hash": "df49e3306f232ec28f1604e36a202847"
+    },
+    "ReportGenerator": {
+      "Package": "ReportGenerator",
+      "Version": "0.0.0.9000",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteUsername": "ohdsi",
+      "RemoteRepo": "ReportGenerator",
+      "RemoteRef": "main",
+      "RemoteSha": "9cda6de87b71bf76ed6b1a80fdec59cc94b079a9",
+      "Requirements": [
+        "DatabaseConnector",
+        "R",
+        "SqlRender",
+        "dplyr",
+        "forestplot",
+        "ggplot2",
+        "ggpubr",
+        "quarto",
+        "reactable",
+        "rlang",
+        "tibble",
+        "tidyr"
+      ],
+      "Hash": "9663385277b95685150db6a80aea3482"
+    },
     "ResultModelManager": {
       "Package": "ResultModelManager",
-      "Version": "0.5.9",
+      "Version": "0.5.10",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "OHDSI",
       "RemoteRepo": "ResultModelManager",
       "RemoteRef": "main",
-      "RemoteSha": "d939010caf5fdc4e898c6e6d1c68d39dc86dc77f",
+      "RemoteSha": "c734b7e55a851f8e1eba0d2a0f78f4a1603641ff",
       "Requirements": [
         "DBI",
         "DatabaseConnector",
@@ -531,7 +596,21 @@
         "withr",
         "zip"
       ],
-      "Hash": "c61b8bc75b92103f1248e7e1a2f04f3b"
+      "Hash": "b709d7c3d4d59b9d4e8dc52f79901997"
+    },
+    "SparseM": {
+      "Package": "SparseM",
+      "Version": "1.84-2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "graphics",
+        "methods",
+        "stats",
+        "utils"
+      ],
+      "Hash": "e78499cbcbbca98200254bd171379165"
     },
     "SqlRender": {
       "Package": "SqlRender",
@@ -544,6 +623,18 @@
         "rlang"
       ],
       "Hash": "e1762de0f08b14658d74989c10e2f265"
+    },
+    "abind": {
+      "Package": "abind",
+      "Version": "1.4-5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "methods",
+        "utils"
+      ],
+      "Hash": "4f57884290cc75ab22f4af9e9d4ca862"
     },
     "anytime": {
       "Package": "anytime",
@@ -719,6 +810,18 @@
       ],
       "Hash": "40415719b5a479b87949f3aa0aee737c"
     },
+    "boot": {
+      "Package": "boot",
+      "Version": "1.3-28.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "graphics",
+        "stats"
+      ],
+      "Hash": "9a052fbcbe97a98ceb18dbfd30ebd96e"
+    },
     "brew": {
       "Package": "brew",
       "Version": "1.0-10",
@@ -735,6 +838,27 @@
         "R"
       ],
       "Hash": "68bd2b066e1fe780bbf62fc8bcc36de3"
+    },
+    "broom": {
+      "Package": "broom",
+      "Version": "1.0.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "backports",
+        "dplyr",
+        "ellipsis",
+        "generics",
+        "glue",
+        "lifecycle",
+        "purrr",
+        "rlang",
+        "stringr",
+        "tibble",
+        "tidyr"
+      ],
+      "Hash": "fd25391c3c4f6ecf0fa95f1e6d15378c"
     },
     "bslib": {
       "Package": "bslib",
@@ -780,6 +904,40 @@
         "utils"
       ],
       "Hash": "9f0e4fae4963ba775a5e5c520838c87b"
+    },
+    "car": {
+      "Package": "car",
+      "Version": "3.1-2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "MASS",
+        "R",
+        "abind",
+        "carData",
+        "grDevices",
+        "graphics",
+        "lme4",
+        "mgcv",
+        "nlme",
+        "nnet",
+        "pbkrtest",
+        "quantreg",
+        "scales",
+        "stats",
+        "utils"
+      ],
+      "Hash": "839b351f31d56e0147439eb22c00a66a"
+    },
+    "carData": {
+      "Package": "carData",
+      "Version": "3.0-5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "ac6cdb8552c61bd36b0e54d07cf2aab7"
     },
     "checkmate": {
       "Package": "checkmate",
@@ -860,6 +1018,13 @@
       "Source": "Repository",
       "Repository": "CRAN",
       "Hash": "5d8225445acb167abf7797de48b2ee3c"
+    },
+    "corrplot": {
+      "Package": "corrplot",
+      "Version": "0.94",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "b575018abd67c252491ffce5ecb94630"
     },
     "cowplot": {
       "Package": "cowplot",
@@ -1049,6 +1214,30 @@
       ],
       "Hash": "698ece7ba5a4fa4559e3d537e7ec3d31"
     },
+    "doBy": {
+      "Package": "doBy",
+      "Version": "4.6.22",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Deriv",
+        "MASS",
+        "Matrix",
+        "R",
+        "boot",
+        "broom",
+        "cowplot",
+        "dplyr",
+        "ggplot2",
+        "methods",
+        "microbenchmark",
+        "modelr",
+        "rlang",
+        "tibble",
+        "tidyr"
+      ],
+      "Hash": "a9b56885b9596c284168df26d6179c40"
+    },
     "downlit": {
       "Package": "downlit",
       "Version": "0.4.3",
@@ -1178,6 +1367,19 @@
       ],
       "Hash": "1a0a9a3d5083d0d573c4214576f1e690"
     },
+    "forestplot": {
+      "Package": "forestplot",
+      "Version": "3.1.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "abind",
+        "checkmate",
+        "grid"
+      ],
+      "Hash": "c81710c7c50653e96ba5349d0456b32c"
+    },
     "fs": {
       "Package": "fs",
       "Version": "1.6.3",
@@ -1239,7 +1441,7 @@
     },
     "gert": {
       "Package": "gert",
-      "Version": "2.1.0",
+      "Version": "2.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1250,7 +1452,7 @@
         "sys",
         "zip"
       ],
-      "Hash": "bdc909d9f16e2478d615b0e6a7330435"
+      "Hash": "ab2ca7d6bd706ed218d096b7b16d7233"
     },
     "ggplot2": {
       "Package": "ggplot2",
@@ -1276,6 +1478,74 @@
         "withr"
       ],
       "Hash": "52ef83f93f74833007f193b2d4c159a2"
+    },
+    "ggpubr": {
+      "Package": "ggpubr",
+      "Version": "0.6.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cowplot",
+        "dplyr",
+        "ggplot2",
+        "ggrepel",
+        "ggsci",
+        "ggsignif",
+        "glue",
+        "grid",
+        "gridExtra",
+        "magrittr",
+        "polynom",
+        "purrr",
+        "rlang",
+        "rstatix",
+        "scales",
+        "stats",
+        "tibble",
+        "tidyr",
+        "utils"
+      ],
+      "Hash": "c957612b8bb1ee9ab7b2450d26663e7e"
+    },
+    "ggrepel": {
+      "Package": "ggrepel",
+      "Version": "0.9.5",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "Rcpp",
+        "ggplot2",
+        "grid",
+        "rlang",
+        "scales",
+        "withr"
+      ],
+      "Hash": "cc3361e234c4a5050e29697d675764aa"
+    },
+    "ggsci": {
+      "Package": "ggsci",
+      "Version": "3.2.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "ggplot2",
+        "grDevices",
+        "scales"
+      ],
+      "Hash": "0c3268cddf4d3a3ce4e7e6330f8e92c8"
+    },
+    "ggsignif": {
+      "Package": "ggsignif",
+      "Version": "0.6.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "ggplot2"
+      ],
+      "Hash": "a57f0f5dbcfd0d77ad4ff33032f5dc79"
     },
     "ggupset": {
       "Package": "ggupset",
@@ -1625,6 +1895,32 @@
       ],
       "Hash": "e2fca3e12e4db979dccc6e519b10a7ee"
     },
+    "lme4": {
+      "Package": "lme4",
+      "Version": "1.1-35.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "MASS",
+        "Matrix",
+        "R",
+        "Rcpp",
+        "RcppEigen",
+        "boot",
+        "graphics",
+        "grid",
+        "lattice",
+        "methods",
+        "minqa",
+        "nlme",
+        "nloptr",
+        "parallel",
+        "splines",
+        "stats",
+        "utils"
+      ],
+      "Hash": "862f9d995f528f3051f524791955b20c"
+    },
     "lubridate": {
       "Package": "lubridate",
       "Version": "1.9.3",
@@ -1689,6 +1985,17 @@
       ],
       "Hash": "086028ca0460d0c368028d3bda58f31b"
     },
+    "microbenchmark": {
+      "Package": "microbenchmark",
+      "Version": "1.4.10",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "graphics",
+        "stats"
+      ],
+      "Hash": "db81b552e393ed092872cf7023469bc2"
+    },
     "mime": {
       "Package": "mime",
       "Version": "0.12",
@@ -1710,6 +2017,34 @@
         "utils"
       ],
       "Hash": "fec5f52652d60615fdb3957b3d74324a"
+    },
+    "minqa": {
+      "Package": "minqa",
+      "Version": "1.2.6",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Rcpp"
+      ],
+      "Hash": "f48238f8d4740426ca12f53f27d004dd"
+    },
+    "modelr": {
+      "Package": "modelr",
+      "Version": "0.1.11",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "broom",
+        "magrittr",
+        "purrr",
+        "rlang",
+        "tibble",
+        "tidyr",
+        "tidyselect",
+        "vctrs"
+      ],
+      "Hash": "4f50122dc256b1b6996a4703fecea821"
     },
     "munsell": {
       "Package": "munsell",
@@ -1735,6 +2070,38 @@
         "utils"
       ],
       "Hash": "8d1938040a05566f4f7a14af4feadd6b"
+    },
+    "nloptr": {
+      "Package": "nloptr",
+      "Version": "2.0.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "testthat"
+      ],
+      "Hash": "277c67a08f358f42b6a77826e4492f79"
+    },
+    "nnet": {
+      "Package": "nnet",
+      "Version": "7.3-18",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "stats",
+        "utils"
+      ],
+      "Hash": "170da2130d5332bea7d6ede01875ba1d"
+    },
+    "numDeriv": {
+      "Package": "numDeriv",
+      "Version": "2016.8-1.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "df58958f293b166e4ab885ebcad90e02"
     },
     "openssl": {
       "Package": "openssl",
@@ -1774,6 +2141,24 @@
         "utils"
       ],
       "Hash": "6e8b139c1904f5e9e14c69db64453bbe"
+    },
+    "pbkrtest": {
+      "Package": "pbkrtest",
+      "Version": "0.5.3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "MASS",
+        "Matrix",
+        "R",
+        "broom",
+        "doBy",
+        "dplyr",
+        "lme4",
+        "methods",
+        "numDeriv"
+      ],
+      "Hash": "938e6bbc4ac57534f8b43224506a8966"
     },
     "pillar": {
       "Package": "pillar",
@@ -1907,6 +2292,17 @@
       ],
       "Hash": "a1ac5c03ad5ad12b9d1597e00e23c3dd"
     },
+    "polynom": {
+      "Package": "polynom",
+      "Version": "1.4-1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "graphics",
+        "stats"
+      ],
+      "Hash": "ceb5c2a59ba33d42d051285a3e8a5118"
+    },
     "pool": {
       "Package": "pool",
       "Version": "1.0.3",
@@ -2022,6 +2418,44 @@
         "vctrs"
       ],
       "Hash": "1cba04a4e9414bdefc9dcaa99649a8dc"
+    },
+    "quantreg": {
+      "Package": "quantreg",
+      "Version": "5.98",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "MASS",
+        "Matrix",
+        "MatrixModels",
+        "R",
+        "SparseM",
+        "graphics",
+        "methods",
+        "stats",
+        "survival"
+      ],
+      "Hash": "017561f17632c065388b7062da030952"
+    },
+    "quarto": {
+      "Package": "quarto",
+      "Version": "1.4.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "cli",
+        "jsonlite",
+        "later",
+        "processx",
+        "rlang",
+        "rmarkdown",
+        "rstudioapi",
+        "tools",
+        "utils",
+        "yaml"
+      ],
+      "Hash": "af456d7a181750812bd8b2bfedb3ea4e"
     },
     "rJava": {
       "Package": "rJava",
@@ -2179,7 +2613,7 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.27",
+      "Version": "2.28",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2198,7 +2632,7 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "27f9502e1cdbfa195f94e03b0f517484"
+      "Hash": "062470668513dcda416927085ee9bdc7"
     },
     "roxygen2": {
       "Package": "roxygen2",
@@ -2235,6 +2669,29 @@
         "R"
       ],
       "Hash": "4c8415e0ec1e29f3f4f6fc108bef0144"
+    },
+    "rstatix": {
+      "Package": "rstatix",
+      "Version": "0.7.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "broom",
+        "car",
+        "corrplot",
+        "dplyr",
+        "generics",
+        "magrittr",
+        "purrr",
+        "rlang",
+        "stats",
+        "tibble",
+        "tidyr",
+        "tidyselect",
+        "utils"
+      ],
+      "Hash": "5045fbb71b143878d8c51975d1d7d56d"
     },
     "rstudioapi": {
       "Package": "rstudioapi",
@@ -2417,6 +2874,17 @@
       ],
       "Hash": "e418b532e9bb4eb22a714b9a9f1acee7"
     },
+    "shinyglide": {
+      "Package": "shinyglide",
+      "Version": "0.1.4",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "htmltools",
+        "shiny"
+      ],
+      "Hash": "b54012e005da3fc3469b7de5148f8f66"
+    },
     "shinyjqui": {
       "Package": "shinyjqui",
       "Version": "0.4.1",
@@ -2509,6 +2977,22 @@
         "vctrs"
       ],
       "Hash": "960e2ae9e09656611e0b8214ad543207"
+    },
+    "survival": {
+      "Package": "survival",
+      "Version": "3.5-3",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Matrix",
+        "R",
+        "graphics",
+        "methods",
+        "splines",
+        "stats",
+        "utils"
+      ],
+      "Hash": "aea2b8787db7088ba50ba389848569ee"
     },
     "sys": {
       "Package": "sys",

--- a/renv.lock
+++ b/renv.lock
@@ -282,7 +282,7 @@
       "RemoteUsername": "FINNGEN",
       "RemoteRepo": "HadesExtras",
       "RemoteRef": "experimental-ak",
-      "RemoteSha": "97063596295e454b7178c3fe2dc7375e2b1557bd",
+      "RemoteSha": "aa9100b5f328e6ecc519823fd948f60c5e0639a7",
       "Remotes": "OHDSI/DatabaseConnector, OHDSI/FeatureExtraction, OHDSI/CohortGenerator, OHDSI/ResultModelManager, OHDSI/Eunomia, javier-gracia-tabuenca-tuni/CohortDiagnostics@fix-error-with-no-conceptset-cohorts",
       "Requirements": [
         "CohortDiagnostics",
@@ -316,7 +316,7 @@
         "tippy",
         "validate"
       ],
-      "Hash": "b5054977ea515189672576a4fb074888"
+      "Hash": "c654bddf2e28817c7c6371dfe491ec51"
     },
     "MASS": {
       "Package": "MASS",

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,11 +2,13 @@
 local({
 
   # the requested version of renv
-  version <- "1.0.3"
+  version <- "1.0.7"
   attr(version, "sha") <- NULL
 
   # the project directory
-  project <- getwd()
+  project <- Sys.getenv("RENV_PROJECT")
+  if (!nzchar(project))
+    project <- getwd()
 
   # use start-up diagnostics if enabled
   diagnostics <- Sys.getenv("RENV_STARTUP_DIAGNOSTICS", unset = "FALSE")
@@ -31,6 +33,14 @@ local({
     if (!is.null(override))
       return(override)
 
+    # if we're being run in a context where R_LIBS is already set,
+    # don't load -- presumably we're being run as a sub-process and
+    # the parent process has already set up library paths for us
+    rcmd <- Sys.getenv("R_CMD", unset = NA)
+    rlibs <- Sys.getenv("R_LIBS", unset = NA)
+    if (!is.na(rlibs) && !is.na(rcmd))
+      return(FALSE)
+
     # next, check environment variables
     # TODO: prefer using the configuration one in the future
     envvars <- c(
@@ -50,8 +60,21 @@ local({
 
   })
 
-  if (!enabled)
+  # bail if we're not enabled
+  if (!enabled) {
+
+    # if we're not enabled, we might still need to manually load
+    # the user profile here
+    profile <- Sys.getenv("R_PROFILE_USER", unset = "~/.Rprofile")
+    if (file.exists(profile)) {
+      cfg <- Sys.getenv("RENV_CONFIG_USER_PROFILE", unset = "TRUE")
+      if (tolower(cfg) %in% c("true", "t", "1"))
+        sys.source(profile, envir = globalenv())
+    }
+
     return(FALSE)
+
+  }
 
   # avoid recursion
   if (identical(getOption("renv.autoloader.running"), TRUE)) {
@@ -105,6 +128,21 @@ local({
   
     tail <- paste(rep.int(suffix, n), collapse = "")
     paste0(prefix, " ", label, " ", tail)
+  
+  }
+  
+  heredoc <- function(text, leave = 0) {
+  
+    # remove leading, trailing whitespace
+    trimmed <- gsub("^\\s*\\n|\\n\\s*$", "", text)
+  
+    # split into lines
+    lines <- strsplit(trimmed, "\n", fixed = TRUE)[[1L]]
+  
+    # compute common indent
+    indent <- regexpr("[^[:space:]]", lines)
+    common <- min(setdiff(indent, -1L)) - leave
+    paste(substring(lines, common), collapse = "\n")
   
   }
   
@@ -610,6 +648,9 @@ local({
   
     # if the user has requested an automatic prefix, generate it
     auto <- Sys.getenv("RENV_PATHS_PREFIX_AUTO", unset = NA)
+    if (is.na(auto) && getRversion() >= "4.4.0")
+      auto <- "TRUE"
+  
     if (auto %in% c("TRUE", "True", "true", "1"))
       return(renv_bootstrap_platform_prefix_auto())
   
@@ -801,24 +842,23 @@ local({
   
     # the loaded version of renv doesn't match the requested version;
     # give the user instructions on how to proceed
-    remote <- if (!is.null(description[["RemoteSha"]])) {
+    dev <- identical(description[["RemoteType"]], "github")
+    remote <- if (dev)
       paste("rstudio/renv", description[["RemoteSha"]], sep = "@")
-    } else {
+    else
       paste("renv", description[["Version"]], sep = "@")
-    }
   
     # display both loaded version + sha if available
     friendly <- renv_bootstrap_version_friendly(
       version = description[["Version"]],
-      sha     = description[["RemoteSha"]]
+      sha     = if (dev) description[["RemoteSha"]]
     )
   
-    fmt <- paste(
-      "renv %1$s was loaded from project library, but this project is configured to use renv %2$s.",
-      "- Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.",
-      "- Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.",
-      sep = "\n"
-    )
+    fmt <- heredoc("
+      renv %1$s was loaded from project library, but this project is configured to use renv %2$s.
+      - Use `renv::record(\"%3$s\")` to record renv %1$s in the lockfile.
+      - Use `renv::restore(packages = \"renv\")` to install renv %2$s into the project library.
+    ")
     catf(fmt, friendly, renv_bootstrap_version_friendly(version), remote)
   
     FALSE
@@ -1041,7 +1081,7 @@ local({
     # if jsonlite is loaded, use that instead
     if ("jsonlite" %in% loadedNamespaces()) {
   
-      json <- catch(renv_json_read_jsonlite(file, text))
+      json <- tryCatch(renv_json_read_jsonlite(file, text), error = identity)
       if (!inherits(json, "error"))
         return(json)
   
@@ -1050,7 +1090,7 @@ local({
     }
   
     # otherwise, fall back to the default JSON reader
-    json <- catch(renv_json_read_default(file, text))
+    json <- tryCatch(renv_json_read_default(file, text), error = identity)
     if (!inherits(json, "error"))
       return(json)
   
@@ -1063,14 +1103,14 @@ local({
   }
   
   renv_json_read_jsonlite <- function(file = NULL, text = NULL) {
-    text <- paste(text %||% read(file), collapse = "\n")
+    text <- paste(text %||% readLines(file, warn = FALSE), collapse = "\n")
     jsonlite::fromJSON(txt = text, simplifyVector = FALSE)
   }
   
   renv_json_read_default <- function(file = NULL, text = NULL) {
   
     # find strings in the JSON
-    text <- paste(text %||% read(file), collapse = "\n")
+    text <- paste(text %||% readLines(file, warn = FALSE), collapse = "\n")
     pattern <- '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]'
     locs <- gregexpr(pattern, text, perl = TRUE)[[1]]
   
@@ -1118,14 +1158,14 @@ local({
     map <- as.list(map)
   
     # remap strings in object
-    remapped <- renv_json_remap(json, map)
+    remapped <- renv_json_read_remap(json, map)
   
     # evaluate
     eval(remapped, envir = baseenv())
   
   }
   
-  renv_json_remap <- function(json, map) {
+  renv_json_read_remap <- function(json, map) {
   
     # fix names
     if (!is.null(names(json))) {
@@ -1152,7 +1192,7 @@ local({
     # recurse
     if (is.recursive(json)) {
       for (i in seq_along(json)) {
-        json[i] <- list(renv_json_remap(json[[i]], map))
+        json[i] <- list(renv_json_read_remap(json[[i]], map))
       }
     }
   

--- a/tests/testmanual/test-mod_FormTimeWindows.R
+++ b/tests/testmanual/test-mod_FormTimeWindows.R
@@ -10,7 +10,7 @@ shiny::shinyApp(
   function(input,output,session){
     output <- mod_formTimeWindows_server("test", session)
 
-    observe({
+    shiny::observe({
         print(output())
     })
 

--- a/tests/testmanual/test-mod_ImportCohortsFromAtlas.R
+++ b/tests/testmanual/test-mod_ImportCohortsFromAtlas.R
@@ -1,6 +1,8 @@
 # build parameters --------------------------------------------------------------
 devtools::load_all(".")
-source(testthat::test_path("setup.R"))
+
+testConfigFile <- "devatlas_databasesConfig.yml"
+databasesConfig <- yaml::read_yaml(testthat::test_path("config", testConfigFile))
 source(testthat::test_path("helper.R"))
 
 logger <- fcr_setUpLogger()
@@ -26,10 +28,10 @@ app <- shiny::shinyApp(
     mod_importCohortsFromAtlas_ui("test")
   ),
   function(input,output,session){
-    mod_importCohortsFromAtlas_server("test", r_connectionHandlers, r_workbench, filterCohortsRegex='PENIS')
+    mod_importCohortsFromAtlas_server("test", r_connectionHandlers, r_workbench)
     mod_cohortWorkbench_server("test", r_connectionHandlers, r_workbench)
   },
-  options = list(launch.browser=TRUE)
+  options = list(launch.browser=TRUE, port = 8081)
 )
 
 pathToCohortOperationsConfigYalm = testthat::test_path("config", "cohortOperationsConfig.yml")

--- a/tests/testmanual/test-mod_TemporalRanges.R
+++ b/tests/testmanual/test-mod_TemporalRanges.R
@@ -8,7 +8,7 @@ shiny::shinyApp(
   function(input,output,session){
     output <-.mod_timeRange_server("test")
 
-    observe({
+    shiny::observe({
       print(output())
     })
   },
@@ -26,7 +26,7 @@ shiny::shinyApp(
   function(input,output,session){
     output <- mod_temporalRanges_server("test", session)
 
-    observe({
+    shiny::observe({
       print(output())
     })
 

--- a/tests/testmanual/test-mod_fct_covariatesSelector.R
+++ b/tests/testmanual/test-mod_fct_covariatesSelector.R
@@ -20,7 +20,7 @@ shiny::shinyApp(
   function(input,output,session){
 
 
-    observe({
+    shiny::observe({
       print(input$test)
     })
 

--- a/tests/testthat/config/cohortOperationsConfig.yml
+++ b/tests/testthat/config/cohortOperationsConfig.yml
@@ -1,2 +1,3 @@
 urlCohortOperationsViewer: "http://127.0.0.1:9998/?pathToResultsZip="
 webApiUrl: "https://api.ohdsi.org/WebAPI"
+# webApiUrl: "http://127.0.0.1:8787/WebAPI"

--- a/tests/testthat/config/devatlas_databasesConfig.yml
+++ b/tests/testthat/config/devatlas_databasesConfig.yml
@@ -20,6 +20,27 @@ BQ1:
     cohortTable:
       cohortDatabaseSchema: atlas-development-270609.sandbox
       cohortTableName: test_cohort_table
+BQ2:
+  cohortTableHandler:
+    database:
+      databaseId: BQ2
+      databaseName: bigquery2
+      databaseDescription: BigQuery database
+    connection:
+      connectionDetailsSettings:
+        dbms: bigquery
+        user: ""
+        password: ""
+        connectionString: jdbc:bigquery://https://www.googleapis.com/bigquery/v2:443;ProjectId=atlas-development-270609;OAuthType=0;OAuthServiceAcctEmail=146473670970-compute@developer.gserviceaccount.com;OAuthPvtKeyPath=/Users/javier/keys/atlas-development-270609-410deaacc58b.json;Timeout=100000;
+        pathToDriver: /Users/javier/.config/hades/bigquery
+      tempEmulationSchema: atlas-development-270609.sandbox #optional
+      useBigrqueryUpload: true #optional
+    cdm:
+      cdmDatabaseSchema: atlas-development-270609.etl_sam_r11_omop
+      vocabularyDatabaseSchema: atlas-development-270609.etl_sam_r11_omop
+    cohortTable:
+      cohortDatabaseSchema: atlas-development-270609.sandbox
+      cohortTableName: test_cohort_table
 #  atlasConfig:
 #     webapi:
 #     resultsshchema:


### PR DESCRIPTION
Main updates:
- When the cohort is imported, first it is checked that the cohort has a generation in the ATLAS in the same CDM that is selected in the CohortOperations by a user and whether this generation is valid. If it is, then the cohort generation is copied from ATLAS BQ to CohortOperations BQ. Otherwise, the cohort is generated from scratch.
- Additionally, a short estimation on the bytes billed by BQ is added (dryrun) and printed in logs when possible. This is an experimental functionality.
