### PR TITLE
Fix: Show task relevant log entries in modals. Show log entries when shiny-server disconnects.

### DIFF
--- a/R/app_Ui.R
+++ b/R/app_Ui.R
@@ -192,6 +192,9 @@ app_ui <- function(request) {
       shinydashboard::dashboardBody(
         do.call(shinydashboard::tabItems, listOfTabs)
       )
-    )
+    ),
+      # Open logfile if app crashes, to avoid shiny grey screen
+    .showLogWhenDisconnected()
+
   )
 }

--- a/R/fct_Configuration.R
+++ b/R/fct_Configuration.R
@@ -50,59 +50,6 @@ fct_assertdatabasesConfig  <- function(databasesConfig) {
   return(collection)
 }
 
-#' Set Up Logger
-#'
-#' Sets up a logger with console and file appenders for logging.
-#'
-#' @return A logger object.
-#'
-#' @export
-fcr_setUpLogger  <- function(){
-
-  timestamp  <- timestamp <- as.character(as.numeric(format(Sys.time(), "%d%m%Y%H%M%OS2"))*100)
-  folderWithLog <- file.path(tempdir(),  paste0("logs", timestamp))
-  dir.create(folderWithLog, showWarnings = FALSE)
-  logger <- ParallelLogger::createLogger(
-    threshold = "TRACE",
-    appenders = list(
-      # to console for tracking
-      .createConsoleAppenderForSandboxLogging(),
-      # to file for showing in app
-      ParallelLogger::createFileAppender(
-        fileName = file.path(folderWithLog, "log.txt"),
-        layout = ParallelLogger::layoutSimple
-      )
-    )
-  )
-  ParallelLogger::clearLoggers()
-  #addDefaultFileLogger(file.path(folderWithLog, "log2.txt"))
-  ParallelLogger::registerLogger(logger)
-
-  shiny::addResourcePath("logs", folderWithLog)
-
-}
-
-
-#' Create Console Appender for Sandbox Logging
-#'
-#' Creates a console appender for sandbox logging with a specified layout.
-#'
-#' @param layout A layout function for the logger. Defaults to ParallelLogger::layoutParallel.
-#'
-#' @return An appender object for logging.
-#'
-.createConsoleAppenderForSandboxLogging <- function(layout = ParallelLogger::layoutParallel) {
-  appendFunction <- function(this, level, message, echoToConsole) {
-    # Avoid note in check:
-    missing(this)
-    message <- paste0("[sandbox-co2-log] ", message)
-    writeLines(message, con = stderr())
-  }
-  appender <- list(appendFunction = appendFunction, layout = layout)
-  class(appender) <- "Appender"
-  return(appender)
-}
-
 #' Convert String to Function
 #'
 #' Converts a string in the format "package::function" to the actual function.

--- a/R/fct_logs.R
+++ b/R/fct_logs.R
@@ -1,0 +1,187 @@
+
+#' Set Up Logger
+#'
+#' Sets up a logger with console and file appenders for logging.
+#'
+#' @return A logger object.
+#'
+#' @export
+fcr_setUpLogger  <- function(){
+
+  timestamp  <- timestamp <- as.character(as.numeric(format(Sys.time(), "%d%m%Y%H%M%OS2"))*100)
+  folderWithLog <- file.path(tempdir(),  paste0("logs", timestamp))
+  dir.create(folderWithLog, showWarnings = FALSE)
+  logger <- ParallelLogger::createLogger(
+    threshold = "TRACE",
+    appenders = list(
+      # to console for tracking
+      .createConsoleAppenderForSandboxLogging(),
+      # to file for showing in app
+      ParallelLogger::createFileAppender(
+        fileName = file.path(folderWithLog, "log.txt"),
+        layout = ParallelLogger::layoutTimestamp
+      )
+    )
+  )
+  ParallelLogger::clearLoggers()
+  #addDefaultFileLogger(file.path(folderWithLog, "log2.txt"))
+  ParallelLogger::registerLogger(logger)
+
+  shiny::addResourcePath("logs", folderWithLog)
+
+}
+
+
+#' Create Console Appender for Sandbox Logging
+#'
+#' Creates a console appender for sandbox logging with a specified layout.
+#'
+#' @param layout A layout function for the logger. Defaults to ParallelLogger::layoutParallel.
+#'
+#' @return An appender object for logging.
+#'
+.createConsoleAppenderForSandboxLogging <- function(layout = ParallelLogger::layoutParallel) {
+  appendFunction <- function(this, level, message, echoToConsole) {
+    # Avoid note in check:
+    missing(this)
+    message <- paste0("[sandbox-co2-log] ", message)
+    writeLines(message, con = stderr())
+  }
+  appender <- list(appendFunction = appendFunction, layout = layout)
+  class(appender) <- "Appender"
+  return(appender)
+}
+
+
+.redirectToLogWhenDisconnected <- function() {
+  # inspired by the approach in shinydisconnect package on https://github.com/daattali/shinydisconnect
+  shiny::tagList(
+    shiny::tags$head(
+      shiny::tags$style(HTML("
+        #custom-disconnect-overlay {
+          position: fixed;
+          top: 0; left: 0; right: 0; bottom: 0;
+          background-color: rgba(0, 0, 0, 0.6);
+          z-index: 9998;
+          display: none;
+        }
+        #custom-disconnect-dialog {
+          position: fixed;
+          top: 30%;
+          left: 50%;
+          transform: translateX(-50%);
+          background-color: white;
+          padding: 20px 30px;
+          font-size: 18px;
+          border-radius: 8px;
+          z-index: 9999;
+          text-align: center;
+          display: none;
+          box-shadow: 0 0 15px rgba(0, 0, 0, 0.4);
+        }
+      ")),
+      shiny::tags$script(HTML("
+        $(document).on('shiny:disconnected', function(event) {
+          console.error('Shiny disconnected. Showing dialog...');
+          $('#custom-disconnect-overlay').show();
+          $('#custom-disconnect-dialog').show();
+          setTimeout(function() {
+            window.open('/logs/log.txt', '_blank');
+          }, 4000); // Wait 4 seconds before opening log file
+        });
+      "))
+    ),
+
+    # The overlay and dialog box HTML
+    shiny::tags$div(id = "custom-disconnect-overlay"),
+    shiny::tags$div(id = "custom-disconnect-dialog", "An error occurred. You will be redirected to the log file...")
+  )
+}
+
+.showLogWhenDisconnected <- function() {
+  shiny::tagList(
+    shiny::tags$head(
+      shiny::tags$style(HTML("
+        #custom-disconnect-overlay {
+          position: fixed;
+          top: 0; left: 0; right: 0; bottom: 0;
+          background-color: rgba(0, 0, 0, 0.6);
+          z-index: 9998;
+          display: none;
+        }
+        #custom-disconnect-dialog {
+          position: fixed;
+          top: 10%;
+          left: 50%;
+          transform: translateX(-50%);
+          background-color: white;
+          padding: 20px;
+          font-size: 16px;
+          border-radius: 8px;
+          z-index: 9999;
+          width: 80%;
+          max-height: 80%;
+          overflow: auto;
+          box-shadow: 0 0 15px rgba(0, 0, 0, 0.4);
+          display: none;
+        }
+        #custom-log-content {
+          text-align: left;
+          font-family: monospace;
+          white-space: pre-wrap;
+          max-height: 60vh;
+          overflow-y: auto;
+          border: 1px solid #ccc;
+          padding: 10px;
+          background-color: #f7f7f7;
+          margin-top: 10px;
+        }
+      ")),
+      shiny::tags$script(HTML("
+        $(document).on('shiny:disconnected', function(event) {
+          console.error('Shiny disconnected. Fetching log file...');
+          $('#custom-disconnect-overlay').show();
+          $('#custom-disconnect-dialog').show();
+          $('#custom-log-content').text('Loading log file...');
+
+          fetch('/logs/log.txt')
+            .then(response => response.text())
+            .then(text => {
+              $('#custom-log-content').text(text);
+            })
+            .catch(error => {
+              $('#custom-log-content').text('Could not load log file.');
+              console.error('Error loading log:', error);
+            });
+        });
+
+         $(document).on('shiny:error', function(event) {
+          console.error('Shiny error. Fetching log file...');
+          $('#custom-disconnect-overlay').show();
+          $('#custom-disconnect-dialog').show();
+          $('#custom-log-content').text('Loading log file...');
+
+          fetch('/logs/log.txt')
+            .then(response => response.text())
+            .then(text => {
+              $('#custom-log-content').text(text);
+            })
+            .catch(error => {
+              $('#custom-log-content').text('Could not load log file.');
+              console.error('Error loading log:', error);
+            });
+        });
+
+      "))
+    ),
+
+    # The overlay and dialog box HTML
+    shiny::tags$div(id = "custom-disconnect-overlay"),
+    shiny::tags$div(id = "custom-disconnect-dialog",
+    shiny::tags$div("You've been disconnected due to inactivity or error. The log file content is shown below for troubleshooting:"),
+    shiny::tags$div(id = "custom-log-content")
+    )
+  )
+}
+
+

--- a/R/fct_spiner.R
+++ b/R/fct_spiner.R
@@ -30,7 +30,7 @@ ui_load_spinner <- function(ui_element, ...) {
 #'
 #'
 #' @importFrom shinyWidgets show_alert
-fct_sweetAlertSpinner <- function(message, logUrl = "/logs/log.txt", updateMiliseconds = 500, ...) {
+fct_sweetAlertSpinner <- function(message, logUrl = "/logs/log.txt", updateMiliseconds = 5000, ...) {
 
   showModal(modalDialog(
     shiny::tags$div(
@@ -38,37 +38,81 @@ fct_sweetAlertSpinner <- function(message, logUrl = "/logs/log.txt", updateMilis
       ui_load_spinner(shiny::plotOutput(outputId = "plot", width = "100px", height = "100px"), proxy.height = "90px"),
       shiny::HTML(paste0(
         "<script>
-          function updateText() {
-              fetch('", logUrl, "')
-                .then(response => {
-                  if (!response.ok) {
-                    throw new Error('Network response was not OK', response);
-                  }
-                  return response.text();
-                })
-                .then(text => {
-                  // console.log('Text from URL:', text);
-                  // Do something with the text here
-                  text = String(text);
-                  const lastlines = text.split('\\n').slice(-10).join('\\n');
+        (function() {
+          let latestTimestamp = null;
+          window.lastShownLine = window.lastShownLine || null;
+          let isFetching = false;
 
-                  if (document.getElementById('updatedText')){
-                    document.getElementById('updatedText').innerHTML = lastlines;
-                  }
+          function updateText(isInitial) {
+            if (isFetching) return;
+            isFetching = true;
 
-                })
-                .catch(error => {
-                  console.error('There was a problem fetching the text:', error);
-                });
+            if (isInitial) {
+                window.lastShownLine = null;
+              }
+
+            fetch('", logUrl, "').then(response => {
+                if (!response.ok) throw new Error('Network response was not OK');
+                return response.text();
+              }).then(text => {
+                const textLines = String(text).split('\\n').filter(line => line.trim() !== '');
+
+                // Find the most recent '[Task Complete]' line
+                const lastTaskCompleteIndex = [...textLines].reverse().findIndex(line => line.includes('[Task Complete]'));
+                const cutoffIndex = lastTaskCompleteIndex >= 0 ? textLines.length - lastTaskCompleteIndex : 0;
+
+                const filteredLines = textLines.slice(cutoffIndex);
+
+                // Find new lines after lastShownLine
+                let newEntries = [];
+                if (window.lastShownLine !== null) {
+                  const lastIndex = filteredLines.findIndex(line => line === window.lastShownLine);
+                  if (lastIndex >= 0 && lastIndex < filteredLines.length - 1) {
+                    newEntries = filteredLines.slice(lastIndex + 1);
+                  } else if (lastIndex === -1) {
+                    // lastShownLine not found — maybe file reset
+                    newEntries = filteredLines;
+                  }
+                } else {
+                  newEntries = filteredLines;
+                }
+
+                // Update latestTimestamp from new entries
+                const timestamps = newEntries.map(line => {
+                    const match = line.match(/^(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2})/);
+                    return match ? new Date(match[1]) : null;
+                  }).filter(ts => ts !== null);
+
+                if (timestamps.length > 0) {
+                  latestTimestamp = new Date(Math.max(...timestamps.map(ts => ts.getTime())));
+                }
+
+                const logContainer = document.getElementById('updatedText');
+                if (logContainer && newEntries.length > 0) {
+                  const strippedEntries = newEntries.map(line => {
+                    const trimmedLine = line.trim();
+                    const match = trimmedLine.match(/^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\u0009(.+)$/);
+                    return match ? match[1] : trimmedLine;  // fallback to full line if no match. To show log entries with timestamp, match[0]
+
+                   });
+                  const prefix = logContainer.textContent.trim().length > 0 ? '\\n' : '';
+                  logContainer.textContent += prefix + strippedEntries.join('\\n');
+                  window.lastShownLine = newEntries[newEntries.length - 1];
+                }
+
+                isFetching = false;
+              })
+              .catch(error => {
+                console.error('Fetch error:', error);
+                isFetching = false;
+              });
           }
 
-          // Update text every 5 seconds
-          setInterval(updateText, ", as.integer(updateMiliseconds),");
-
-          // Call updateText initially to update the text when the page loads
-          updateText();
-        </script>
-        <pre id='updatedText' style='border: 1px solid #ccc; padding: 10px; text-align: left;'></pre>"
+          updateText(true);
+          setInterval(() => updateText(false), ", as.integer(updateMiliseconds), ");
+        })();
+      </script>
+      <pre id='updatedText' style='border: 1px solid #ccc; padding: 10px; text-align: left; min-height: 300px; max-height: 300px; overflow-y: auto; display: block; white-space: pre-wrap;'></pre>"
       ))
       # attendantBar("progress-bar", hidden = TRUE, max=1000)
     ),
@@ -96,10 +140,9 @@ fct_sweetAlertSpinner <- function(message, logUrl = "/logs/log.txt", updateMilis
 #'
 #' @importFrom shinyWidgets closeSweetAlert
 fct_removeSweetAlertSpinner <- function() {
+  ParallelLogger::logInfo("[Task Complete]")
   removeModal()
 }
-
-
 
 
 .listToString <- function(list) {


### PR DESCRIPTION
Display only relevant log entries during long-running task modals (fixes #63 ).
Show log entries in a modal on Shiny disconnect errors instead of the default grey screen (fixes #93 ).

These changes improve both user experience and error visibility.
Closes #63 
Closes #93 