### PR TITLE
Fix unnecessary triggering of disconnection log display

### DIFF
--- a/R/fct_logs.R
+++ b/R/fct_logs.R
@@ -111,24 +111,24 @@ fcr_setUpLogger  <- function(){
             });
         });
 
-        #  $(document).on('shiny:error', function(event) {
-        #   console.error('Shiny error. Fetching log file...');
-        #   $('#custom-disconnect-overlay').show();
-        #   $('#custom-disconnect-dialog').show();
-        #   $('#custom-log-content').text('Loading log file...');
+        $(document).on('shiny:error', function(event) {
+         console.error('Shiny error. Fetching log file...');
+         $('#custom-disconnect-overlay').show();
+         $('#custom-disconnect-dialog').show();
+         $('#custom-log-content').text('Loading log file...');
 
-        #   fetch('/logs/log.txt')
-        #     .then(response => response.text())
-        #     .then(text => {
-        #       const lines = text.trim().split('\\n');
-        #       const last10 = lines.slice(-10).join('\\n');
-        #       $('#custom-log-content').text(last10);
-        #     })
-        #     .catch(error => {
-        #       $('#custom-log-content').text('Could not load log file.');
-        #       console.error('Error loading log:', error);
-        #     });
-        # });
+         fetch('/logs/log.txt')
+           .then(response => response.text())
+           .then(text => {
+             const lines = text.trim().split('\\n');
+             const last10 = lines.slice(-10).join('\\n');
+             $('#custom-log-content').text(last10);
+           })
+           .catch(error => {
+             $('#custom-log-content').text('Could not load log file.');
+             console.error('Error loading log:', error);
+           });
+       });
 
       "))
     ),

--- a/R/mod_MatchCohorts.R
+++ b/R/mod_MatchCohorts.R
@@ -272,9 +272,10 @@ mod_matchCohorts_server <- function(id, r_databaseConnection) {
     # Render temporal name
     #
     output$info_text <- shiny::renderText({
-      shiny::req(r$cohortDefinitionSet)
-      shiny::req(input$selectCaseCohort_pickerInput)
-      shiny::req(input$selectControlCohort_pickerInput)
+
+      if (!shiny::isTruthy(r$cohortDefinitionSet) || !shiny::isTruthy(input$selectCaseCohort_pickerInput) || !shiny::isTruthy(input$selectControlCohort_pickerInput)) {
+        return("")
+      }
 
       cohortsOverlap <- r_databaseConnection$cohortTableHandler$getCohortsOverlap()
       cohortCounts <-  r_databaseConnection$cohortTableHandler$getCohortCounts()


### PR DESCRIPTION
Checking of user input is done for the rendertext function used for the pre-run info in the match cohort module to avoid empty or null returns, which triggers a shiny error event. This is not a needed behavior. The same should be done for the renderText functions for the CodeWas, Time Code WAS, GWAS analysis module from CO2AnalysisModules here:

https://github.com/FINNGEN/CO2AnalysisModules/blob/master/R/mod_analysisSettings_CodeWAS.R
https://github.com/FINNGEN/CO2AnalysisModules/blob/master/R/mod_analysisSettings_TimeCodeWAS.R
https://github.com/FINNGEN/CO2AnalysisModules/blob/master/R/mod_analysisSettings_GWAS.R