### PR TITLE
Hotfix: prevent silent shiny error when data is missing in reactable

### DIFF
--- a/R/mod_ImportCohortsFromAtlas.R
+++ b/R/mod_ImportCohortsFromAtlas.R
@@ -93,7 +93,7 @@ mod_importCohortsFromAtlas_server <- function(id, r_databaseConnection, filterCo
     # render cohorts_reactable
     #
     output$cohorts_reactable <- reactable::renderReactable({
-      shiny::req(r$atlasCohortsTable)
+      shiny::req(r$atlasCohortsTable, cancelOutput = TRUE)
       atlasCohortsTable <- r$atlasCohortsTable
 
       if (is.character(atlasCohortsTable)) {

--- a/R/mod_ImportCohortsFromFile.R
+++ b/R/mod_ImportCohortsFromFile.R
@@ -213,8 +213,8 @@ mod_importCohortsFromFile_server <- function(id, r_databaseConnection) {
     # updates output$cohorts_reactable with r$cohortDefinitionSetImported
     #
     output$cohorts_reactable <- reactable::renderReactable({
-      shiny::req(r_cohortData$data)
-      shiny::req(r_cohortData$validated == TRUE)
+      req(!is.null(r_cohortData$data), cancelOutput = TRUE)
+      req(isTRUE(r_cohortData$validated), cancelOutput = TRUE)
 
       .reactatable_cohortData(r_cohortData$data)
     })

--- a/R/mod_fileImportModals.R
+++ b/R/mod_fileImportModals.R
@@ -227,7 +227,7 @@ mapping_server <- function(id, r_dataToMap, r_cohortData, regex_person_id) {
   shiny::moduleServer(id, function(input, output, session) {
     # Summary table
     output$input_table <- reactable::renderReactable({
-      shiny::req(r_dataToMap$data)
+      req(!is.null(r_dataToMap$data), cancelOutput = TRUE)
       reactable::reactable(
         data = utils::head(r_dataToMap$data, 5),
         striped = TRUE,


### PR DESCRIPTION
This fixes silent error triggered by req when used within render functions. This was occurring when pages are initially loaded and before any data is provided by users, which was inducing the log displaying shiny:error event. Now it is fixed so that it waits until data is available before continuing with rendering.