### PR TITLE
Fixed crashing when the control cohort list is empty.

### DIFF
--- a/R/fct_spiner.R
+++ b/R/fct_spiner.R
@@ -100,6 +100,10 @@ fct_sweetAlertSpinner <- function(message, logUrl = "/logs/log.txt", updateMilis
                   window.lastShownLine = newEntries[newEntries.length - 1];
                 }
 
+                if (logContainer) {
+                  logContainer.scrollTop = logContainer.scrollHeight;
+                }
+
                 isFetching = false;
               })
               .catch(error => {

--- a/R/mod_MatchCohorts.R
+++ b/R/mod_MatchCohorts.R
@@ -155,7 +155,6 @@ mod_matchCohorts_server <- function(id, r_databaseConnection) {
       )
     })
 
-
     #
     # update matchToCohortId_pickerInput with cohort names not in selectCaseCohort_pickerInput
     #
@@ -166,7 +165,11 @@ mod_matchCohorts_server <- function(id, r_databaseConnection) {
 
       cohortIdAndNames <- r_databaseConnection$cohortTableHandler$getCohortIdAndNames()|>
           dplyr::filter(!(cohortId %in% input$selectCaseCohort_pickerInput))
-      cohortIdAndNamesList <- as.list(setNames(cohortIdAndNames$cohortId, paste(cohortIdAndNames$shortName, "("  , cohortIdAndNames$cohortName, ")")))
+
+      cohortIdAndNamesList <- list()
+      if(nrow(cohortIdAndNames) != 0){
+        cohortIdAndNamesList <- as.list(setNames(cohortIdAndNames$cohortId, paste(cohortIdAndNames$shortName, "("  , cohortIdAndNames$cohortName, ")")))
+      }
 
       shinyWidgets::updatePickerInput(
         inputId = "selectControlCohort_pickerInput",


### PR DESCRIPTION
This fixes crashing when there is only one cohort in the workbench and cohort matching is attempted, fixes #177 